### PR TITLE
Refactor: Moved initialization of edit fields to a separate method to…

### DIFF
--- a/MainForm/AddTransactionForm.cs
+++ b/MainForm/AddTransactionForm.cs
@@ -43,19 +43,26 @@ namespace MainForm
 
             comboBoxTransictionType_SelectedIndexChanged_1(null, null);
 
-            int catIndex = comboBoxTransactionCategory.Items.IndexOf(transactionToEdit.Category);
-            if (catIndex >= 0)
-                comboBoxTransactionCategory.SelectedIndex = catIndex;
+            InitializeEditMode(transactionToEdit);
+        }
 
+        private void InitializeEditMode(Transaction transactionToEdit)
+        {
+            SelectComboBoxItemIfExists(comboBoxTransactionCategory, transactionToEdit.Category);
             comboBoxTransactionCategory_SelectedIndexChanged(null, null);
 
-            int subIndex = comboBoxSubCategory.Items.IndexOf(transactionToEdit.Subcategory);
-            if (subIndex >= 0)
-                comboBoxSubCategory.SelectedIndex = subIndex;
+            SelectComboBoxItemIfExists(comboBoxSubCategory, transactionToEdit.Subcategory);
 
             textBoxSum.Text = transactionToEdit.Amount.ToString();
             textBoxTransactionDescription.Text = transactionToEdit.Description;
             dateTimePickerTransaction.Value = transactionToEdit.Date;
+        }
+
+        private void SelectComboBoxItemIfExists(ComboBox comboBox, string item)
+        {
+            int index = comboBox.Items.IndexOf(item);
+            if (index >= 0)
+                comboBox.SelectedIndex = index;
         }
 
         private void buttonTransactionSave_Click(object sender, EventArgs e)


### PR DESCRIPTION
The transaction edit form constructor had duplicated code for setting selected items in the ComboBox and other fields, making the code difficult to maintain and extend.

Proposed solution:

Moved the initialization of the edit form fields into a separate method, InitializeEditMode(), and added a helper method, SelectComboBoxItemIfExists(), to reuse the logic for selecting an item in the ComboBox. This improves readability, maintainability, and makes it easier to add new changes in the future.